### PR TITLE
fix: 移除莫奈取色并修复QTH历史弹窗与提交后焦点回归

### DIFF
--- a/android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java
+++ b/android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java
@@ -16,11 +16,6 @@ public final class GeneratedPluginRegistrant {
   private static final String TAG = "GeneratedPluginRegistrant";
   public static void registerWith(@NonNull FlutterEngine flutterEngine) {
     try {
-      flutterEngine.getPlugins().add(new io.material.plugins.dynamic_color.DynamicColorPlugin());
-    } catch (Exception e) {
-      Log.e(TAG, "Error registering plugin dynamic_color, io.material.plugins.dynamic_color.DynamicColorPlugin", e);
-    }
-    try {
       flutterEngine.getPlugins().add(new com.mr.flutter.plugin.filepicker.FilePickerPlugin());
     } catch (Exception e) {
       Log.e(TAG, "Error registering plugin file_picker, com.mr.flutter.plugin.filepicker.FilePickerPlugin", e);

--- a/android/local.properties
+++ b/android/local.properties
@@ -1,4 +1,4 @@
 flutter.sdk=/home/mazha0309/develop/flutter
 sdk.dir=/home/mazha0309/Android/Sdk
 flutter.buildMode=release
-flutter.versionName=0.9.0+1
+flutter.versionName=0.9.1+1

--- a/lib/config/version.dart
+++ b/lib/config/version.dart
@@ -1,1 +1,1 @@
-const String appVersion = '0.9.0';
+const String appVersion = '0.9.1';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:dynamic_color/dynamic_color.dart';
 import 'package:provider/provider.dart';
 import 'package:openlogtool/providers/log_provider.dart';
 import 'package:openlogtool/providers/dictionary_provider.dart';
@@ -19,10 +18,8 @@ void main() {
   }
 
   runApp(
-    DynamicColorBuilder(
-      builder: (lightDynamic, darkDynamic) {
-        return MultiProvider(
-          providers: [
+    MultiProvider(
+      providers: [
         ChangeNotifierProvider(create: (_) => AppInfoProvider()..loadAppInfo()),
         ChangeNotifierProvider(create: (_) => SnackbarLogProvider()),
         ChangeNotifierProvider(create: (_) => SettingsProvider()),
@@ -71,46 +68,32 @@ void main() {
             return provider;
           },
         ),
-        ],
-        child: MyApp(
-          lightDynamic: lightDynamic,
-          darkDynamic: darkDynamic,
-        ),
-      );
-    },
-  ),
+      ],
+      child: const MyApp(),
+    ),
   );
 }
 
 class MyApp extends StatelessWidget {
-  final ColorScheme? lightDynamic;
-  final ColorScheme? darkDynamic;
-
-  const MyApp({super.key, this.lightDynamic, this.darkDynamic});
+  const MyApp({super.key});
 
   @override
   Widget build(BuildContext context) {
     final settingsProvider = Provider.of<SettingsProvider>(context);
-    final isDark = settingsProvider.isDarkMode;
     final themeColor = settingsProvider.themeColor;
     final fontFamily = settingsProvider.fontFamily;
 
-
-    final baseLight = (lightDynamic != null && settingsProvider.monetColorEnabled)
-        ? lightDynamic!
-        : ColorScheme.fromSeed(seedColor: themeColor, brightness: Brightness.light);
-    final baseDark = (darkDynamic != null && settingsProvider.monetColorEnabled)
-        ? darkDynamic!
-        : ColorScheme.fromSeed(seedColor: themeColor, brightness: Brightness.dark);
-
-    final vividRed = const Color(0xFFDC2626);
+    const vividRed = Color(0xFFDC2626);
 
     return MaterialApp(
       title: 'OpenLogTool',
       debugShowCheckedModeBanner: false,
       theme: ThemeData(
         useMaterial3: true,
-        colorScheme: baseLight.harmonized().copyWith(error: vividRed),
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: themeColor,
+          brightness: Brightness.light,
+        ).copyWith(error: vividRed),
         fontFamily: fontFamily,
         cardTheme: CardThemeData(
           elevation: 0,
@@ -136,7 +119,10 @@ class MyApp extends StatelessWidget {
       ),
       darkTheme: ThemeData(
         useMaterial3: true,
-        colorScheme: baseDark.harmonized().copyWith(error: vividRed),
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: themeColor,
+          brightness: Brightness.dark,
+        ).copyWith(error: vividRed),
         fontFamily: fontFamily,
         cardTheme: CardThemeData(
           elevation: 0,

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -13,7 +13,6 @@ class SettingsProvider with ChangeNotifier {
   static const String _callSignQthLinkKey = 'callSignQthLinkEnabled';
   static const String _paginationEnabledKey = 'paginationEnabled';
   static const String _importCallsignQthHistoryKey = 'importCallsignQthHistoryEnabled';
-  static const String _monetColorEnabledKey = 'monetColorEnabled';
 
   bool _wideLayoutEnabled = false;
   Color _themeColor = const Color(0xFF2196F3);
@@ -24,7 +23,6 @@ class SettingsProvider with ChangeNotifier {
   bool _callSignQthLinkEnabled = true;
   bool _paginationEnabled = false;
   bool _importCallsignQthHistoryEnabled = true;
-  bool _monetColorEnabled = false;
 
   bool get wideLayoutEnabled => _wideLayoutEnabled;
   Color get themeColor => _themeColor;
@@ -35,7 +33,6 @@ class SettingsProvider with ChangeNotifier {
   bool get callSignQthLinkEnabled => _callSignQthLinkEnabled;
   bool get paginationEnabled => _paginationEnabled;
   bool get importCallsignQthHistoryEnabled => _importCallsignQthHistoryEnabled;
-  bool get monetColorEnabled => _monetColorEnabled;
 
   SettingsProvider() {
     _loadSettings();
@@ -67,7 +64,6 @@ class SettingsProvider with ChangeNotifier {
     _callSignQthLinkEnabled = prefs.getBool(_callSignQthLinkKey) ?? true;
     _paginationEnabled = prefs.getBool(_paginationEnabledKey) ?? false;
     _importCallsignQthHistoryEnabled = prefs.getBool(_importCallsignQthHistoryKey) ?? true;
-    _monetColorEnabled = prefs.getBool(_monetColorEnabledKey) ?? false;
 
     notifyListeners();
   }
@@ -123,12 +119,6 @@ class SettingsProvider with ChangeNotifier {
   Future<void> setImportCallsignQthHistory(bool enabled) async {
     _importCallsignQthHistoryEnabled = enabled;
     await _saveSetting(_importCallsignQthHistoryKey, enabled);
-    notifyListeners();
-  }
-
-  Future<void> setMonetColor(bool enabled) async {
-    _monetColorEnabled = enabled;
-    await _saveSetting(_monetColorEnabledKey, enabled);
     notifyListeners();
   }
 

--- a/lib/widgets/log_form.dart
+++ b/lib/widgets/log_form.dart
@@ -26,6 +26,7 @@ final GlobalKey<QthFieldWithHistoryState> _qthFieldKey =
       GlobalKey<QthFieldWithHistoryState>();
   final _controllerController = TextEditingController();
   final _callsignController = TextEditingController();
+  final FocusNode _callsignFocusNode = FocusNode();
   final _deviceController = TextEditingController();
   final _antennaController = TextEditingController();
   final _powerController = TextEditingController();
@@ -44,6 +45,7 @@ final GlobalKey<QthFieldWithHistoryState> _qthFieldKey =
   void dispose() {
     _controllerController.dispose();
     _callsignController.dispose();
+    _callsignFocusNode.dispose();
     _deviceController.dispose();
     _antennaController.dispose();
     _powerController.dispose();
@@ -139,7 +141,7 @@ final GlobalKey<QthFieldWithHistoryState> _qthFieldKey =
       _controllerError = null;
       _reportError = null;
     });
-    FocusScope.of(context).requestFocus(FocusNode());
+    FocusScope.of(context).requestFocus(_callsignFocusNode);
   }
 
   @override
@@ -192,6 +194,7 @@ final GlobalKey<QthFieldWithHistoryState> _qthFieldKey =
                       dictionaryOptions: dictionaryProvider.callsignDict,
                       label: '点名呼号',
                       hintText: '输入呼号',
+                      focusNode: _callsignFocusNode,
                       isCompact: isNarrow,
                       textInputAction: TextInputAction.next,
                     ),
@@ -434,6 +437,7 @@ final GlobalKey<QthFieldWithHistoryState> _qthFieldKey =
     required String label,
     required String hintText,
     TextInputAction? textInputAction,
+    FocusNode? focusNode,
     bool isCompact = false,
   }) {
     return Autocomplete<DictionaryItem>(
@@ -460,7 +464,7 @@ final GlobalKey<QthFieldWithHistoryState> _qthFieldKey =
         });
         return TextFormField(
           controller: fieldController,
-          focusNode: fieldFocusNode,
+          focusNode: focusNode ?? fieldFocusNode,
           decoration: InputDecoration(
             labelText: label,
             hintText: hintText,

--- a/lib/widgets/qth_field_with_history.dart
+++ b/lib/widgets/qth_field_with_history.dart
@@ -289,7 +289,7 @@ class QthFieldWithHistoryState extends State<QthFieldWithHistory> {
             });
             return TextFormField(
               controller: fieldController,
-              focusNode: fieldFocusNode,
+              focusNode: _focusNode,
               decoration: InputDecoration(
                 labelText: widget.label,
                 hintText: widget.hintText,

--- a/lib/widgets/settings/theme_settings.dart
+++ b/lib/widgets/settings/theme_settings.dart
@@ -78,29 +78,6 @@ class ThemeSettings extends StatelessWidget {
               ],
             ),
             const SizedBox(height: 12),
-            // Monet 莫奈取色
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text('莫奈取色',
-                          style: TextStyle(fontSize: isNarrow ? 13 : 14)),
-                      const SizedBox(height: 2),
-                      const Text('在Android 12+上自动提取壁纸颜色',
-                          style: TextStyle(fontSize: 12, color: Colors.grey)),
-                    ],
-                  ),
-                ),
-                Switch(
-                  value: settingsProvider.monetColorEnabled,
-                  onChanged: (v) => settingsProvider.setMonetColor(v),
-                ),
-              ],
-            ),
-            const SizedBox(height: 12),
             // 字体
             Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,13 +6,9 @@
 
 #include "generated_plugin_registrant.h"
 
-#include <dynamic_color/dynamic_color_plugin.h>
 #include <open_file_linux/open_file_linux_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
-  g_autoptr(FlPluginRegistrar) dynamic_color_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "DynamicColorPlugin");
-  dynamic_color_plugin_register_with_registrar(dynamic_color_registrar);
   g_autoptr(FlPluginRegistrar) open_file_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "OpenFileLinuxPlugin");
   open_file_linux_plugin_register_with_registrar(open_file_linux_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,7 +3,6 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
-  dynamic_color
   open_file_linux
 )
 

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,7 +5,6 @@
 import FlutterMacOS
 import Foundation
 
-import dynamic_color
 import file_picker
 import open_file_mac
 import package_info_plus
@@ -13,7 +12,6 @@ import shared_preferences_foundation
 import sqflite_darwin
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
-  DynamicColorPlugin.register(with: registry.registrar(forPlugin: "DynamicColorPlugin"))
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
   OpenFilePlugin.register(with: registry.registrar(forPlugin: "OpenFilePlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -193,14 +193,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.7"
-  dynamic_color:
-    dependency: "direct main"
-    description:
-      name: dynamic_color
-      sha256: "43a5a6679649a7731ab860334a5812f2067c2d9ce6452cf069c5e0c25336c17c"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.8.1"
   equatable:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: openlogtool
 description: OpenLogTool
 publish_to: 'none'
-version: 0.9.0+1
+version: 0.9.1+1
 license: AGPL-3.0
 homepage: https://github.com/Mazha0309/OpenLogTool
 repository: https://github.com/Mazha0309/OpenLogTool.git

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,7 +27,6 @@ dependencies:
   sqflite: ^2.4.0
   sqflite_common_ffi: ^2.3.0
   http: ^1.2.0
-  dynamic_color: ^1.8.1
   web_socket_channel: ^2.4.0
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- 移除不可用的 dynamic_color (莫奈取色)
- 修复 QTH 历史弹窗：焦点切换到 QTH 输入框时正确弹出历史记录
- 修复提交记录后焦点自动回到点名呼号框

## Changes
- `lib/main.dart` — 移除 DynamicColorBuilder，还原纯 Material 主题
- `lib/widgets/qth_field_with_history.dart` — 统一使用 `_focusNode`
- `lib/widgets/log_form.dart` — 添加 `_callsignFocusNode` 并在提交后自动聚焦
- `pubspec.yaml` — 移除 `dynamic_color` 依赖