### PR TITLE
fix(ci): stabilize release and dependency automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,9 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -639,7 +639,7 @@ jobs:
           $destination = Join-Path "dist" $installer.Name
           Copy-Item -LiteralPath $installer.FullName -Destination $destination
           $hash = (Get-FileHash $destination -Algorithm SHA256).Hash.ToLowerInvariant()
-          $hashLine = "$hash  $(Split-Path $destination -Leaf)$([Environment]::NewLine)"
+          $hashLine = "$hash  $(Split-Path $destination -Leaf)`n"
           [System.IO.File]::WriteAllText("$destination.sha256", $hashLine)
 
       - name: Upload Windows artifacts
@@ -842,6 +842,7 @@ jobs:
           (
             cd artifacts
             for checksum in *.sha256; do
+              sed -i 's/\r$//' "$checksum"
               sha256sum --check "$checksum"
             done
             find . -maxdepth 1 -type f ! -name '*.sha256' \


### PR DESCRIPTION
## What changed

- generate the Windows installer checksum with an explicit LF line ending
- normalize checksum files before Linux release verification
- group monthly GitHub Actions Dependabot updates and limit open update PRs

## Why

The v2.0.1-R release failed after all platform builds succeeded because the Windows checksum contained CRLF, so GNU sha256sum interpreted the filename with a trailing carriage return.

## Validation

- workflow YAML parses successfully
- embedded release shell scripts pass syntax checks
- git diff --check passes