### PR TITLE
fix: refresh saved logs and prepare 2.2.1-R

### DIFF
--- a/android/local.properties
+++ b/android/local.properties
@@ -1,4 +1,5 @@
 flutter.sdk=/home/mazha0309/develop/flutter
-sdk.dir=/home/mazha0309/Android/Sdk
+sdk.dir=/home/mazha0309/android-sdk
 flutter.buildMode=release
-flutter.versionName=1.0.0+1
+flutter.versionName=2.2.1-R
+flutter.versionCode=8

--- a/lib/config/version.dart
+++ b/lib/config/version.dart
@@ -1,1 +1,1 @@
-const String appVersion = '2.2.0-R+7';
+const String appVersion = '2.2.1-R+8';

--- a/lib/providers/collaboration_provider.dart
+++ b/lib/providers/collaboration_provider.dart
@@ -2068,6 +2068,18 @@ class CollaborationProvider with ChangeNotifier {
           throw StateError('LIVE_DRAFT_INCOMPLETE:${required.join(',')}');
         }
         try {
+          final logs = _logs;
+          if (logs != null &&
+              logs.currentSessionId != context.binding.sessionId) {
+            await logs.reloadForSession(
+              context.binding.sessionId,
+              propagateErrors: true,
+            );
+            _assertLiveDraftContextCurrent(context);
+            if (logs.currentSessionId != context.binding.sessionId) {
+              throw StateError('LIVE_DRAFT_LOG_CONTEXT_CHANGED');
+            }
+          }
           final committed = await context.api.commitLiveDraft(
             sessionId: context.binding.sessionId,
             deviceId: context.deviceId,
@@ -2076,6 +2088,10 @@ class CollaborationProvider with ChangeNotifier {
             idempotencyKey: mutationId,
           );
           _assertLiveDraftContextCurrent(context);
+          // The server has durably accepted the record. Publish it to the
+          // table before waiting on draft-cache persistence or event catch-up;
+          // either of those can be slow or fail independently of the commit.
+          _stageCommittedLiveDraftLog(committed.record, committed.event);
           _liveDraftSnapshot = LiveDraftSnapshotDto(
             draft: committed.nextDraft,
             locks: const [],
@@ -2092,6 +2108,7 @@ class CollaborationProvider with ChangeNotifier {
           await _refreshLogsAfterLiveDraftCommit(
             context: context,
             event: committed.event,
+            syncId: committed.record.syncId,
           );
           _assertLiveDraftContextCurrent(context);
           _safeNotify();
@@ -2215,6 +2232,7 @@ class CollaborationProvider with ChangeNotifier {
             idempotencyKey: record.mutationId,
           );
           _assertLiveDraftContextCurrent(context);
+          _stageCommittedLiveDraftLog(committed.record, committed.event);
           _liveDraftSnapshot = LiveDraftSnapshotDto(
             draft: committed.nextDraft,
             locks: const [],
@@ -2229,6 +2247,7 @@ class CollaborationProvider with ChangeNotifier {
           await _refreshLogsAfterLiveDraftCommit(
             context: context,
             event: committed.event,
+            syncId: committed.record.syncId,
           );
           _assertLiveDraftContextCurrent(context);
         }
@@ -3544,11 +3563,39 @@ class CollaborationProvider with ChangeNotifier {
   Future<void> _refreshLogsAfterLiveDraftCommit({
     required _LiveDraftContext context,
     required CollaborationEventDto event,
+    required String syncId,
   }) async {
     bool contextIsCurrent() => _isLiveDraftContextCurrent(context);
 
     if (!contextIsCurrent()) return;
-    final canonical = CollaborationLogDto.fromJson(event.payload);
+    final coordinator = _syncCoordinator;
+    if (coordinator != null) {
+      try {
+        final synchronized = await coordinator.synchronizeNow(
+          targetSeq: event.seq,
+          timeout: const Duration(seconds: 1),
+        );
+        if (synchronized && contextIsCurrent()) {
+          await _logs?.reconcileStagedCanonicalLog(syncId);
+          return;
+        }
+        if (!contextIsCurrent()) return;
+      } catch (error, stackTrace) {
+        if (!contextIsCurrent()) return;
+        debugPrint(
+          '[Collaboration] awaited live-draft refresh failed: '
+          '$error\n$stackTrace',
+        );
+      }
+    }
+    if (!contextIsCurrent()) return;
+    coordinator?.wake();
+  }
+
+  void _stageCommittedLiveDraftLog(
+    CollaborationLogDto canonical,
+    CollaborationEventDto event,
+  ) {
     _recordLogAuthorshipFromEvent(event);
     _logs?.stageCanonicalLog(
       LogEntry(
@@ -3570,29 +3617,6 @@ class CollaborationProvider with ChangeNotifier {
         deletedAt: canonical.deletedAt?.toUtc().toIso8601String(),
       ),
     );
-
-    final coordinator = _syncCoordinator;
-    if (coordinator != null) {
-      try {
-        final synchronized = await coordinator.synchronizeNow(
-          targetSeq: event.seq,
-          timeout: const Duration(seconds: 1),
-        );
-        if (synchronized && contextIsCurrent()) {
-          await _logs?.reconcileStagedCanonicalLog(canonical.syncId);
-          return;
-        }
-        if (!contextIsCurrent()) return;
-      } catch (error, stackTrace) {
-        if (!contextIsCurrent()) return;
-        debugPrint(
-          '[Collaboration] awaited live-draft refresh failed: '
-          '$error\n$stackTrace',
-        );
-      }
-    }
-    if (!contextIsCurrent()) return;
-    coordinator?.wake();
   }
 
   Future<void> _refreshLiveDraftForBinding(
@@ -4284,6 +4308,7 @@ class CollaborationProvider with ChangeNotifier {
           idempotencyKey: record.mutationId,
         );
         if (!contextIsCurrent()) return;
+        _stageCommittedLiveDraftLog(committed.record, committed.event);
         _liveDraftSnapshot = LiveDraftSnapshotDto(
           draft: committed.nextDraft,
           locks: const [],
@@ -4318,6 +4343,7 @@ class CollaborationProvider with ChangeNotifier {
         await _refreshLogsAfterLiveDraftCommit(
           context: context,
           event: committed.event,
+          syncId: committed.record.syncId,
         );
         if (!contextIsCurrent()) return;
       } on ServerApiException catch (error) {

--- a/lib/providers/log_provider.dart
+++ b/lib/providers/log_provider.dart
@@ -375,9 +375,33 @@ class LogProvider with ChangeNotifier {
 
   Future<void> addLog(old.LogEntry log, {String? sessionId}) async {
     final effectiveSessionId = sessionId ?? _currentSessionId ?? '';
+    if (effectiveSessionId.isEmpty) {
+      throw StateError('SESSION_CONTEXT_MISSING: 当前没有可写会话');
+    }
+
+    // The form follows SessionProvider, while this provider owns the table
+    // projection. During startup or a session switch those two providers can
+    // briefly point at different sessions. Align before writing so a
+    // successful insert cannot be followed by a reload of the old session.
+    if (_currentSessionId != effectiveSessionId) {
+      await reloadForSession(effectiveSessionId, propagateErrors: true);
+    }
+    if (_currentSessionId != effectiveSessionId) {
+      throw StateError(
+        'SESSION_CONTEXT_CHANGED: 会话已切换，请重新保存当前记录',
+      );
+    }
     _ensureWritable(effectiveSessionId);
     try {
       final canonical = await _logCreator(effectiveSessionId, log);
+      if (canonical.sessionId != effectiveSessionId) {
+        throw StateError(
+          'LOG_SESSION_MISMATCH: 保存结果与当前会话不匹配',
+        );
+      }
+      // The user may switch sessions while the durable insert is in flight.
+      // The row is already saved, but it must never leak into the newly opened
+      // session's in-memory table.
       if (_currentSessionId == effectiveSessionId) {
         _mergeCanonicalLog(canonical);
       }

--- a/lib/widgets/callsign_history_field.dart
+++ b/lib/widgets/callsign_history_field.dart
@@ -223,21 +223,6 @@ class _CallsignHistoryFieldState extends State<CallsignHistoryField> {
     if (_canFill('height') && (log.height?.isNotEmpty ?? false)) {
       widget.heightController.text = log.height!;
     }
-    if (_canFill('rstSent') &&
-        widget.reportController != null &&
-        (log.rstSent?.isNotEmpty ?? false)) {
-      widget.reportController!.text = log.rstSent!;
-    }
-    if (_canFill('rstRcvd') &&
-        widget.rstRcvdController != null &&
-        (log.rstRcvd?.isNotEmpty ?? false)) {
-      widget.rstRcvdController!.text = log.rstRcvd!;
-    }
-    if (_canFill('controller') &&
-        widget.controllerController != null &&
-        log.controller.isNotEmpty) {
-      widget.controllerController!.text = log.controller;
-    }
   }
 
   void _showOverlay() {

--- a/lib/widgets/log_form.dart
+++ b/lib/widgets/log_form.dart
@@ -262,9 +262,6 @@ class _LogFormState extends State<LogForm> with AutomaticKeepAliveClientMixin {
       if (record.qth?.isNotEmpty ?? false) 'qth': record.qth!,
       if (record.power?.isNotEmpty ?? false) 'power': record.power!,
       if (record.height?.isNotEmpty ?? false) 'height': record.height!,
-      if (record.rstSent?.isNotEmpty ?? false) 'rstSent': record.rstSent!,
-      if (record.rstRcvd?.isNotEmpty ?? false) 'rstRcvd': record.rstRcvd!,
-      if (record.controller.isNotEmpty) 'controller': record.controller,
     };
     if (values.isEmpty || !mounted) return;
 
@@ -327,7 +324,8 @@ class _LogFormState extends State<LogForm> with AutomaticKeepAliveClientMixin {
     if (_submissionInProgress) return;
     final collaboration = context.read<CollaborationProvider>();
     if (widget.readOnly ||
-        (collaboration.liveDraftSnapshot != null &&
+        (collaboration.binding != null &&
+            collaboration.liveDraftSnapshot != null &&
             !collaboration.canEditLiveDraft)) {
       return;
     }
@@ -404,7 +402,8 @@ class _LogFormState extends State<LogForm> with AutomaticKeepAliveClientMixin {
     }
     if (!mounted) return;
 
-    if (collaboration.liveDraftSnapshot != null) {
+    if (collaboration.binding != null &&
+        collaboration.liveDraftSnapshot != null) {
       final enteredTime = _timeController.text.trim();
       final submittedTime =
           enteredTime.isNotEmpty ? enteredTime : _getCurrentTime();

--- a/lib/widgets/log_table.dart
+++ b/lib/widgets/log_table.dart
@@ -139,9 +139,16 @@ class _LogTableState extends State<LogTable> {
 
   @override
   Widget build(BuildContext context) {
-    final logProvider = Provider.of<LogProvider>(context);
-    final settingsProvider = Provider.of<SettingsProvider>(context);
+    final logProvider = context.watch<LogProvider>();
+    final settingsProvider = context.watch<SettingsProvider>();
+    return _buildContent(context, logProvider, settingsProvider);
+  }
 
+  Widget _buildContent(
+    BuildContext context,
+    LogProvider logProvider,
+    SettingsProvider settingsProvider,
+  ) {
     if (logProvider.logs.isEmpty) {
       return Container(
         margin: const EdgeInsets.all(16),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: openlogtool
 description: OpenLogTool
 publish_to: 'none'
-version: 2.2.0-R+7
+version: 2.2.1-R+8
 license: AGPL-3.0
 homepage: https://github.com/Mazha0309/OpenLogTool
 repository: https://github.com/Mazha0309/OpenLogTool.git

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1016,7 +1016,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openlogtool_core"
-version = "2.2.0-R"
+version = "2.2.1-R"
 dependencies = [
  "anyhow",
  "chrono",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openlogtool_core"
-version = "2.2.0-R"
+version = "2.2.1-R"
 edition = "2021"
 license = "AGPL-3.0"
 

--- a/test/providers/log_provider_mutation_test.dart
+++ b/test/providers/log_provider_mutation_test.dart
@@ -37,6 +37,92 @@ void main() {
     provider.dispose();
   });
 
+  test('add aligns a stale table projection to the requested session',
+      () async {
+    final provider = LogProvider(
+      sessionListLoader: () async => [
+        _session('old-session'),
+        _session('new-session'),
+      ],
+      sessionLogPageLoader: (sessionId, _, __) async =>
+          sessionId == 'old-session'
+              ? [
+                  _bridgeLog(
+                    id: 'old-row',
+                    sessionId: 'old-session',
+                    time: '2026-07-13T10:00:00Z',
+                  ),
+                ]
+              : [],
+      logCreator: (sessionId, _) async {
+        expect(sessionId, 'new-session');
+        return _bridgeLog(
+          id: 'new-row',
+          sessionId: 'new-session',
+          time: '2026-07-13T11:00:00Z',
+          callsign: 'BG5FRESH',
+        );
+      },
+    );
+    await provider.reloadForSession('old-session');
+    expect(provider.logs.single.id, 'old-row');
+
+    await provider.addLog(
+      _modelLog(id: 'temporary', sessionId: 'new-session'),
+      sessionId: 'new-session',
+    );
+
+    expect(provider.currentSessionId, 'new-session');
+    expect(provider.logs.map((log) => log.id), ['new-row']);
+    expect(provider.logs.single.callsign, 'BG5FRESH');
+    provider.dispose();
+  });
+
+  test('an add finishing after a session switch cannot pollute the new table',
+      () async {
+    final createStarted = Completer<void>();
+    final releaseCreate = Completer<void>();
+    final provider = LogProvider(
+      sessionListLoader: () async => [
+        _session('session-a'),
+        _session('session-b'),
+      ],
+      sessionLogPageLoader: (sessionId, _, __) async => sessionId == 'session-b'
+          ? [
+              _bridgeLog(
+                id: 'session-b-row',
+                sessionId: 'session-b',
+                time: '2026-07-13T12:00:00Z',
+              ),
+            ]
+          : [],
+      logCreator: (sessionId, _) async {
+        expect(sessionId, 'session-a');
+        createStarted.complete();
+        await releaseCreate.future;
+        return _bridgeLog(
+          id: 'late-session-a-row',
+          sessionId: 'session-a',
+          time: '2026-07-13T11:00:00Z',
+        );
+      },
+    );
+    await provider.reloadForSession('session-a');
+
+    final add = provider.addLog(
+      _modelLog(id: 'temporary', sessionId: 'session-a'),
+      sessionId: 'session-a',
+    );
+    await createStarted.future;
+    await provider.reloadForSession('session-b');
+    releaseCreate.complete();
+    await add;
+
+    expect(provider.currentSessionId, 'session-b');
+    expect(provider.logs.map((log) => log.id), ['session-b-row']);
+    provider.dispose();
+  });
+
   test('a stale reload cannot overwrite a canonical add', () async {
     final staleReadStarted = Completer<void>();
     final releaseStaleRead = Completer<void>();

--- a/test/widgets/callsign_history_field_test.dart
+++ b/test/widgets/callsign_history_field_test.dart
@@ -117,7 +117,7 @@ void main() {
     expect(find.byIcon(Icons.search), findsOneWidget);
   });
 
-  testWidgets('reuses related fields without changing the current time',
+  testWidgets('reuses station details without changing operator fields',
       (tester) async {
     final callsign = TextEditingController();
     final device = TextEditingController();
@@ -182,9 +182,9 @@ void main() {
     expect(qth.text, '上海');
     expect(power.text, '100W');
     expect(height.text, '12m');
-    expect(rstSent.text, '58');
-    expect(rstRcvd.text, '47');
-    expect(controller.text, 'BG5CRL');
+    expect(rstSent.text, isEmpty);
+    expect(rstRcvd.text, isEmpty);
+    expect(controller.text, isEmpty);
     expect(currentTime.text, '20:42');
   });
 

--- a/test/widgets/log_form_collaboration_test.dart
+++ b/test/widgets/log_form_collaboration_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openlogtool/l10n/l10n.dart';
+import 'package:openlogtool/models/collaboration_dto.dart';
 import 'package:openlogtool/models/live_draft.dart';
 import 'package:openlogtool/providers/collaboration_provider.dart';
 import 'package:openlogtool/providers/dictionary_provider.dart';
@@ -270,11 +271,14 @@ void main() {
           'qth': 'Shanghai',
           'power': '100W',
           'height': '12m',
-          'rstSent': '58',
-          'rstRcvd': '47',
-          'controller': 'BG5CRL',
         });
         expect(collaboration.atomicUpdates.single, isNot(contains('time')));
+        expect(collaboration.atomicUpdates.single, isNot(contains('rstSent')));
+        expect(collaboration.atomicUpdates.single, isNot(contains('rstRcvd')));
+        expect(
+          collaboration.atomicUpdates.single,
+          isNot(contains('controller')),
+        );
         collaboration.acquiredFields.clear();
         collaboration.releasedFields.clear();
 
@@ -806,6 +810,21 @@ class _RecordingCollaborationProvider extends CollaborationProvider {
   LiveDraftCommitDisposition commitDisposition =
       LiveDraftCommitDisposition.committed;
   int commitCalls = 0;
+
+  @override
+  LocalCollaborationBinding get binding => const LocalCollaborationBinding(
+        serverInstanceId: 'server-1',
+        serverOrigin: 'https://example.test',
+        accountId: 'user-1',
+        sessionId: 'session-1',
+        membershipId: 'membership-1',
+        membershipVersion: 1,
+        role: SessionRole.owner,
+        replicaState: 'ready',
+        lastAppliedSeq: 1,
+        lastSeenHeadSeq: 1,
+        revokedAt: null,
+      );
 
   void replaceDraft({
     required String draftId,

--- a/test/widgets/log_table_test.dart
+++ b/test/widgets/log_table_test.dart
@@ -7,11 +7,69 @@ import 'package:openlogtool/models/log_entry.dart';
 import 'package:openlogtool/providers/log_provider.dart';
 import 'package:openlogtool/providers/settings_provider.dart';
 import 'package:openlogtool/providers/snackbar_log_provider.dart';
+import 'package:openlogtool/src/bridge/models/log_entry.dart' as bridge_log;
+import 'package:openlogtool/src/bridge/models/session.dart' as bridge_session;
 import 'package:openlogtool/widgets/log_table.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
+  testWidgets('a successful provider add replaces the empty table immediately',
+      (tester) async {
+    SharedPreferences.setMockInitialValues(
+      <String, Object>{'paginationEnabled': false},
+    );
+    final logProvider = LogProvider(
+      sessionListLoader: () async => [
+        const bridge_session.Session(
+          sessionId: 'table-session',
+          title: 'Table session',
+          status: 'active',
+          createdAt: '2026-07-13T10:00:00Z',
+          updatedAt: '2026-07-13T10:00:00Z',
+        ),
+      ],
+      sessionLogPageLoader: (_, __, ___) async => [],
+      logCreator: (_, __) async => const bridge_log.LogEntry(
+        syncId: 'fresh-row',
+        sessionId: 'table-session',
+        time: '2026-07-13T12:00:00Z',
+        controller: 'BG5CTRL',
+        callsign: 'BG5FRESH',
+        rstSent: '59',
+        rstRcvd: '59',
+        createdAt: '2026-07-13T12:00:00Z',
+        updatedAt: '2026-07-13T12:00:00Z',
+      ),
+    );
+    addTearDown(logProvider.dispose);
+    await logProvider.reloadForSession('table-session');
+    await _pumpLogTable(tester, logProvider);
+    expect(find.text('暂无已保存记录'), findsOneWidget);
+
+    await logProvider.addLog(
+      LogEntry(
+        sessionId: 'table-session',
+        time: '2026-07-13T12:00:00Z',
+        controller: 'BG5CTRL',
+        callsign: 'BG5FRESH',
+        report: '59',
+        rstRcvd: '59',
+        qth: '',
+        device: '',
+        power: '',
+        antenna: '',
+        height: '',
+      ),
+      sessionId: 'table-session',
+    );
+    await tester.pump();
+
+    expect(find.byType(DataTable), findsOneWidget);
+    expect(find.text('BG5FRESH'), findsOneWidget);
+    expect(find.text('暂无已保存记录'), findsNothing);
+  });
+
   testWidgets('keeps RST sent and received aligned with the newest row',
       (tester) async {
     SharedPreferences.setMockInitialValues(


### PR DESCRIPTION
## Summary

- Bump the Flutter and Rust versions to 2.2.1-R with local build number 8.
- Make successful local and collaboration saves appear in the saved-record table immediately.
- Keep session projections aligned during saves and avoid reusing time or signal-report fields from callsign history.
- Add regression coverage for stale sessions, mid-save session switches, collaboration commits, and empty-table refreshes.

## Root cause

Successful writes could target the active session while LogProvider still projected a previous session. Collaboration commits also waited for draft-cache persistence before staging the canonical server record, delaying or losing the UI notification.

## Validation

- flutter analyze --no-pub
- full Flutter test suite: 382 passed
- clean Flutter Linux release build
- flutter pub get
- cargo metadata --no-deps --format-version 1