### PR TITLE
OpenLogTool 2.6.1-R: collaboration recovery and stability

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/v') }}
 
 env:
-  FLUTTER_VERSION: '3.41.4'
+  FLUTTER_VERSION: '3.44.7'
   RUST_VERSION: '1.91.1'
   FRB_CODEGEN_VERSION: '2.12.0'
   CARGO_NDK_VERSION: '4.1.2'

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@
 ## 开始使用
 
 ### 环境要求
-- Flutter SDK 3.41+
-- Dart SDK 3.11+
+- Flutter SDK 3.44+
+- Dart SDK 3.12+
 - Rust toolchain 1.91.1（仓库中的 `rust-toolchain.toml` 会固定版本）
 - Android 构建额外需要 Android NDK 28.2.13676358 与 cargo-ndk 4.1.2
 - Linux 构建需要 `libsecret-1-dev`，运行需要 `libsecret-1-0` 和可用的 Secret Service/keyring

--- a/android/local.properties
+++ b/android/local.properties
@@ -1,5 +1,5 @@
 flutter.sdk=/home/mazha0309/develop/flutter
 sdk.dir=/home/mazha0309/android-sdk
 flutter.buildMode=release
-flutter.versionName=2.6.0-R
-flutter.versionCode=12
+flutter.versionName=2.6.1-R
+flutter.versionCode=13

--- a/lib/config/version.dart
+++ b/lib/config/version.dart
@@ -1,1 +1,1 @@
-const String appVersion = '2.6.0-R+12';
+const String appVersion = '2.6.1-R+13';

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -143,6 +143,8 @@
   "restoreLastDeletedRecordConfirmation": "This restores the most recently deleted net record without changing any other records.",
   "recordRestored": "Record restored",
   "saveRecord": "Save record",
+  "clearEnteredFields": "Clear fields",
+  "enteredFieldsCleared": "Fields cleared; controller callsign retained",
   "recordAdded": "Record saved",
   "recordQueuedOffline": "Saved offline; review after reconnecting",
   "sharedDraftReadOnly": "This shared draft is read-only",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -169,6 +169,8 @@
   "restoreLastDeletedRecordConfirmation": "将恢复最近一次删除的点名记录，不会影响其他记录。",
   "recordRestored": "记录已恢复",
   "saveRecord": "保存记录",
+  "clearEnteredFields": "清空已填内容",
+  "enteredFieldsCleared": "已清空，主控呼号已保留",
   "recordAdded": "记录已添加",
   "recordQueuedOffline": "网络不可用，记录已保存到本机待复核",
   "sharedDraftReadOnly": "当前协作草稿只读",

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -940,6 +940,18 @@ abstract class AppLocalizations {
   /// **'保存记录'**
   String get saveRecord;
 
+  /// No description provided for @clearEnteredFields.
+  ///
+  /// In zh, this message translates to:
+  /// **'清空已填内容'**
+  String get clearEnteredFields;
+
+  /// No description provided for @enteredFieldsCleared.
+  ///
+  /// In zh, this message translates to:
+  /// **'已清空，主控呼号已保留'**
+  String get enteredFieldsCleared;
+
   /// No description provided for @recordAdded.
   ///
   /// In zh, this message translates to:

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -503,6 +503,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get saveRecord => 'Save record';
 
   @override
+  String get clearEnteredFields => 'Clear fields';
+
+  @override
+  String get enteredFieldsCleared =>
+      'Fields cleared; controller callsign retained';
+
+  @override
   String get recordAdded => 'Record saved';
 
   @override

--- a/lib/l10n/generated/app_localizations_zh.dart
+++ b/lib/l10n/generated/app_localizations_zh.dart
@@ -491,6 +491,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get saveRecord => '保存记录';
 
   @override
+  String get clearEnteredFields => '清空已填内容';
+
+  @override
+  String get enteredFieldsCleared => '已清空，主控呼号已保留';
+
+  @override
   String get recordAdded => '记录已添加';
 
   @override

--- a/lib/providers/collaboration_provider.dart
+++ b/lib/providers/collaboration_provider.dart
@@ -12,6 +12,7 @@ import 'package:openlogtool/providers/log_provider.dart';
 import 'package:openlogtool/providers/server_provider.dart';
 import 'package:openlogtool/providers/session_provider.dart';
 import 'package:openlogtool/services/collaboration_publish.dart';
+import 'package:openlogtool/services/collaboration_catalog_restore.dart';
 import 'package:openlogtool/services/collaboration_conflicts.dart';
 import 'package:openlogtool/services/collaboration_replica.dart';
 import 'package:openlogtool/services/collaboration_sync.dart';
@@ -998,6 +999,13 @@ class CollaborationProvider with ChangeNotifier {
   final ResettableLiveDraftSerialExecutor _liveDraftSerial =
       ResettableLiveDraftSerialExecutor();
   Timer? _liveDraftRenewalTimer;
+  Timer? _catalogTimer;
+  Future<void>? _catalogOperation;
+  String? _catalogScope;
+  bool _catalogRefreshScheduled = false;
+  bool _catalogSyncing = false;
+  String? _catalogErrorMessage;
+  int _catalogRestoredCount = 0;
 
   CollaborationState _state = CollaborationState.localOnly;
   LocalCollaborationBinding? _binding;
@@ -1082,6 +1090,9 @@ class CollaborationProvider with ChangeNotifier {
   List<PublicShareDto> get publicShares => _publicShares;
   PublicShareDto? get lastCreatedPublicShare => _lastCreatedPublicShare;
   bool get isBusy => _operationInProgress;
+  bool get catalogSyncing => _catalogSyncing;
+  String? get catalogErrorMessage => _catalogErrorMessage;
+  int get catalogRestoredCount => _catalogRestoredCount;
   bool get canJoinWithInvite {
     final currentBinding = binding;
     return currentBinding == null ||
@@ -1277,6 +1288,7 @@ class CollaborationProvider with ChangeNotifier {
     if (mutationPermissionsChanged) {
       logs.refreshMutationPermissions();
     }
+    _updateCatalogScope(server, sessions);
     final key = '${server.contextRevision}|${server.serverUrl}|'
         '${server.accountId ?? ''}|'
         '${sessions.currentSessionId ?? ''}';
@@ -1287,6 +1299,164 @@ class CollaborationProvider with ChangeNotifier {
     _clearScopedState();
     _safeNotify();
     _scheduleRefresh();
+  }
+
+  void _updateCatalogScope(
+    ServerProvider server,
+    SessionProvider sessions,
+  ) {
+    final info = server.serverInfo;
+    final accountId = server.accountId;
+    final supported = info != null &&
+        info.features.contains('sessionSnapshots') &&
+        info.features.contains('sessionMembership');
+    final nextScope = server.isLoggedIn &&
+            !server.passwordChangeRequired &&
+            accountId != null &&
+            server.serverUrl.isNotEmpty &&
+            supported
+        ? '${info.serverInstanceId}|${server.serverUrl}|$accountId'
+        : null;
+    if (_catalogScope == nextScope) return;
+
+    _catalogScope = nextScope;
+    _catalogTimer?.cancel();
+    _catalogTimer = null;
+    _catalogErrorMessage = null;
+    _catalogRestoredCount = 0;
+    if (nextScope == null) {
+      _catalogSyncing = false;
+      return;
+    }
+
+    _scheduleCatalogRefresh();
+    _catalogTimer = Timer.periodic(
+      const Duration(seconds: 60),
+      (_) => _scheduleCatalogRefresh(),
+    );
+  }
+
+  void _scheduleCatalogRefresh() {
+    if (_catalogRefreshScheduled || _catalogScope == null || _disposed) return;
+    _catalogRefreshScheduled = true;
+    scheduleMicrotask(() async {
+      _catalogRefreshScheduled = false;
+      try {
+        await refreshAccountCollaborationSessions();
+      } catch (error, stackTrace) {
+        debugPrint(
+            '[CollaborationCatalog] refresh failed: $error\n$stackTrace');
+      }
+    });
+  }
+
+  /// Installs collaboration replicas visible to this account but absent from
+  /// the device. This never changes the current Session selection.
+  Future<void> refreshAccountCollaborationSessions() {
+    final current = _catalogOperation;
+    if (current != null) return current;
+    late final Future<void> operation;
+    operation = _refreshAccountCollaborationSessions().whenComplete(() {
+      if (identical(_catalogOperation, operation)) _catalogOperation = null;
+    });
+    _catalogOperation = operation;
+    return operation;
+  }
+
+  Future<void> _refreshAccountCollaborationSessions() async {
+    final scope = _catalogScope;
+    final server = _server;
+    final sessions = _sessions;
+    final info = server?.serverInfo;
+    final accountId = server?.accountId;
+    if (scope == null ||
+        server == null ||
+        sessions == null ||
+        info == null ||
+        accountId == null ||
+        !server.isLoggedIn ||
+        server.passwordChangeRequired) {
+      return;
+    }
+    final contextRevision = server.contextRevision;
+    final serverUrl = server.serverUrl;
+    final serverInstanceId = info.serverInstanceId;
+    bool isCurrent() =>
+        !_disposed &&
+        _catalogScope == scope &&
+        identical(_server, server) &&
+        identical(_sessions, sessions) &&
+        server.contextRevision == contextRevision &&
+        server.serverUrl == serverUrl &&
+        server.accountId == accountId &&
+        server.serverInfo?.serverInstanceId == serverInstanceId;
+
+    _catalogSyncing = true;
+    _catalogErrorMessage = null;
+    _safeNotify();
+    try {
+      final remoteSessions = await server.api.listSessions();
+      if (!isCurrent()) return;
+      final result = await restoreMissingCollaborationSessions(
+        remoteSessions: remoteSessions,
+        accountId: accountId,
+        isCurrent: isCurrent,
+        bindingExists: (sessionId) async {
+          final json = await RustApi.getCollaborationBinding(
+            serverInstanceId: serverInstanceId,
+            accountId: accountId,
+            sessionId: sessionId,
+          );
+          if (json == null) return false;
+          final binding = LocalCollaborationBinding.fromJson(jsonDecode(json));
+          return binding.serverInstanceId == serverInstanceId &&
+              binding.accountId == accountId &&
+              binding.sessionId == sessionId;
+        },
+        loadMembership: server.api.getMembership,
+        loadSnapshot: (sessionId) => server.api.getSessionSnapshot(
+          sessionId,
+          includeDeleted: false,
+        ),
+        installSnapshot: ({required membership, required snapshot}) async {
+          final bindingJson = await RustApi.installCollaborationSnapshot(
+            requestJson: jsonEncode({
+              'mode': 'join',
+              'serverInstanceId': serverInstanceId,
+              'serverOrigin': serverUrl,
+              'accountId': accountId,
+              'membership': membership.toJson(),
+              'snapshot': snapshot.toJson(),
+            }),
+          );
+          final installed = LocalCollaborationBinding.fromJson(
+            jsonDecode(bindingJson),
+          );
+          if (installed.serverInstanceId != serverInstanceId ||
+              installed.accountId != accountId ||
+              installed.sessionId != snapshot.session.sessionId) {
+            throw StateError('COLLABORATION_CATALOG_INSTALL_MISMATCH');
+          }
+        },
+      );
+      if (!isCurrent() || result.cancelled) return;
+      _catalogRestoredCount = result.installedSessionIds.length;
+      if (result.installedSessionIds.isNotEmpty) {
+        sessions.notifyCollaborationCatalogChanged();
+      }
+      if (result.issues.isNotEmpty) {
+        _catalogErrorMessage = result.issues
+            .map((issue) => '${issue.title}: ${issue.error}')
+            .join('\n');
+      }
+    } catch (error) {
+      if (isCurrent()) _catalogErrorMessage = error.toString();
+    } finally {
+      if (isCurrent()) {
+        _catalogSyncing = false;
+        _safeNotify();
+      }
+    }
   }
 
   Future<void> refreshCurrentSession() async {
@@ -2188,8 +2358,8 @@ class CollaborationProvider with ChangeNotifier {
             'OFFLINE_RECORD_QUEUED',
             '网络不可用，记录已保存到本机，恢复连接后将检查是否可安全提交',
           );
-          await _persistLiveDraftState(_guardFor(context));
           _safeNotify();
+          await _persistLiveDraftState(_guardFor(context));
           return LiveDraftCommitDisposition.queuedOffline;
         }
         final canonical = _liveDraftSnapshot;
@@ -2240,6 +2410,10 @@ class CollaborationProvider with ChangeNotifier {
           _liveDraftBaseRevisions = const {};
           _clearOwnedLiveDraftLocks();
           _clearLiveDraftError();
+          // Expose both the new table row and the reset draft immediately.
+          // Cache persistence and event catch-up are durability work and must
+          // not hold the visible form on the previous record.
+          _safeNotify();
           await _persistLiveDraftState(_guardFor(context));
           await _refreshLogsAfterLiveDraftCommit(
             context: context,
@@ -2285,8 +2459,8 @@ class CollaborationProvider with ChangeNotifier {
             'OFFLINE_RECORD_QUEUED',
             '网络不可用，记录已保存到本机，恢复连接后将检查是否可安全提交',
           );
-          await _persistLiveDraftState(_guardFor(context));
           _safeNotify();
+          await _persistLiveDraftState(_guardFor(context));
           return LiveDraftCommitDisposition.queuedOffline;
         }
       });
@@ -2325,8 +2499,8 @@ class CollaborationProvider with ChangeNotifier {
         _liveDraftBaseRevisions = const {};
         _clearOwnedLiveDraftLocks();
         _clearLiveDraftError();
-        await _persistLiveDraftState(_guardFor(context));
         _safeNotify();
+        await _persistLiveDraftState(_guardFor(context));
       });
 
   Future<void> resolveOfflineRecord(
@@ -2380,6 +2554,7 @@ class CollaborationProvider with ChangeNotifier {
           _dirtyLiveDraftFields = const {};
           _liveDraftBaseRevisions = const {};
           _clearOwnedLiveDraftLocks();
+          _safeNotify();
           await _refreshLogsAfterLiveDraftCommit(
             context: context,
             event: committed.event,
@@ -5248,6 +5423,7 @@ class CollaborationProvider with ChangeNotifier {
   @override
   void dispose() {
     _stopSynchronization();
+    _catalogTimer?.cancel();
     _logs?.setLogMutationGuard(null);
     _disposed = true;
     super.dispose();

--- a/lib/providers/session_provider.dart
+++ b/lib/providers/session_provider.dart
@@ -59,6 +59,7 @@ class SessionProvider with ChangeNotifier {
   Session? _currentSession;
   int _databaseRevision = 0;
   int _dataRevision = 0;
+  int _collaborationCatalogRevision = 0;
   // Fail closed until SharedPreferences has proved that no replacement was
   // interrupted. Personal-cloud synchronization awaits [ready], so a
   // preference read failure cannot accidentally expose a stale baseline.
@@ -69,6 +70,7 @@ class SessionProvider with ChangeNotifier {
   Session? get currentSession => _currentSession;
   int get databaseRevision => _databaseRevision;
   int get dataRevision => _dataRevision;
+  int get collaborationCatalogRevision => _collaborationCatalogRevision;
   bool get databaseReplacementPending => _databaseReplacementPending;
 
   Future<void> get ready => _initCompleter?.future ?? Future.value();
@@ -654,6 +656,13 @@ class SessionProvider with ChangeNotifier {
 
   void _markPersonalDataChanged() {
     _dataRevision += 1;
+    _safeNotify();
+  }
+
+  /// Invalidates session-list readers after a background collaboration
+  /// snapshot install without marking personal-cloud data as changed.
+  void notifyCollaborationCatalogChanged() {
+    _collaborationCatalogRevision += 1;
     _safeNotify();
   }
 }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -107,27 +107,38 @@ class _HomeScreenState extends State<HomeScreen> {
             index: _selectedIndex,
             children: pages,
           );
-          if (constraints.maxWidth < 720) return content;
+          final showSidebar = constraints.maxWidth >= 720;
           final isDesktop = constraints.maxWidth >= 1200;
+          // Keep the page stack at a stable element position when crossing the
+          // mobile/sidebar breakpoint. Reparenting the focused TextField while
+          // Windows is dispatching WM_SIZE can tear down its native IME
+          // connection in the middle of that callback.
           return Row(
             children: [
-              PrimaryNavigationRail(
-                isDesktop: isDesktop,
-                expanded: primarySidebarExpanded,
-                selectedIndex: _selectedIndex,
-                onDestinationSelected: _onItemTapped,
-                onExpandedChanged:
-                    context.read<SettingsProvider>().setPrimarySidebarExpanded,
-                destinations: [
-                  for (final destination in _destinations)
-                    NavigationRailDestination(
-                      icon: Icon(destination.icon),
-                      selectedIcon: Icon(destination.selectedIcon),
-                      label: Text(destination.label(context.l10n)),
-                    ),
-                ],
+              if (showSidebar)
+                PrimaryNavigationRail(
+                  isDesktop: isDesktop,
+                  expanded: primarySidebarExpanded,
+                  selectedIndex: _selectedIndex,
+                  onDestinationSelected: _onItemTapped,
+                  onExpandedChanged: context
+                      .read<SettingsProvider>()
+                      .setPrimarySidebarExpanded,
+                  destinations: [
+                    for (final destination in _destinations)
+                      NavigationRailDestination(
+                        icon: Icon(destination.icon),
+                        selectedIcon: Icon(destination.selectedIcon),
+                        label: Text(destination.label(context.l10n)),
+                      ),
+                  ],
+                )
+              else
+                const SizedBox.shrink(),
+              Expanded(
+                key: const ValueKey('home-page-stack'),
+                child: content,
               ),
-              Expanded(child: content),
             ],
           );
         },

--- a/lib/services/collaboration_catalog_restore.dart
+++ b/lib/services/collaboration_catalog_restore.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/foundation.dart';
+import 'package:openlogtool/models/collaboration_dto.dart';
+
+typedef CollaborationBindingExists = Future<bool> Function(String sessionId);
+typedef CollaborationMembershipLoader = Future<MembershipDto> Function(
+  String sessionId,
+);
+typedef CollaborationSnapshotLoader = Future<SessionSnapshotDto> Function(
+  String sessionId,
+);
+typedef CollaborationSnapshotInstaller = Future<void> Function({
+  required MembershipDto membership,
+  required SessionSnapshotDto snapshot,
+});
+
+@immutable
+final class CollaborationCatalogRestoreIssue {
+  const CollaborationCatalogRestoreIssue({
+    required this.sessionId,
+    required this.title,
+    required this.error,
+  });
+
+  final String sessionId;
+  final String title;
+  final Object error;
+}
+
+@immutable
+final class CollaborationCatalogRestoreResult {
+  const CollaborationCatalogRestoreResult({
+    required this.installedSessionIds,
+    required this.issues,
+    required this.cancelled,
+  });
+
+  final List<String> installedSessionIds;
+  final List<CollaborationCatalogRestoreIssue> issues;
+  final bool cancelled;
+}
+
+/// Rebuilds missing local collaboration replicas from the signed-in account's
+/// server catalog without changing the user's current Session selection.
+///
+/// One malformed or temporarily unavailable Session must not prevent other
+/// historical Sessions from being recovered on a new device.
+Future<CollaborationCatalogRestoreResult> restoreMissingCollaborationSessions({
+  required List<CollaborationSessionDto> remoteSessions,
+  required String accountId,
+  required CollaborationBindingExists bindingExists,
+  required CollaborationMembershipLoader loadMembership,
+  required CollaborationSnapshotLoader loadSnapshot,
+  required CollaborationSnapshotInstaller installSnapshot,
+  bool Function()? isCurrent,
+}) async {
+  final installed = <String>[];
+  final issues = <CollaborationCatalogRestoreIssue>[];
+  final stillCurrent = isCurrent ?? () => true;
+
+  for (final remote in remoteSessions) {
+    if (!stillCurrent()) {
+      return CollaborationCatalogRestoreResult(
+        installedSessionIds: List.unmodifiable(installed),
+        issues: List.unmodifiable(issues),
+        cancelled: true,
+      );
+    }
+    // An interrupted publish has no stable canonical history to restore yet.
+    if (remote.status == 'initializing' || remote.deletedAt != null) continue;
+
+    try {
+      if (await bindingExists(remote.sessionId)) continue;
+      if (!stillCurrent()) continue;
+
+      final membership = await loadMembership(remote.sessionId);
+      if (!stillCurrent()) continue;
+      if (membership.sessionId != remote.sessionId ||
+          membership.userId != accountId ||
+          membership.removedAt != null) {
+        throw StateError('COLLABORATION_CATALOG_MEMBERSHIP_MISMATCH');
+      }
+
+      final snapshot = await loadSnapshot(remote.sessionId);
+      if (!stillCurrent()) continue;
+      if (snapshot.session.sessionId != remote.sessionId) {
+        throw StateError('COLLABORATION_CATALOG_SNAPSHOT_MISMATCH');
+      }
+
+      await installSnapshot(membership: membership, snapshot: snapshot);
+      if (!stillCurrent()) continue;
+      installed.add(remote.sessionId);
+    } catch (error) {
+      if (!stillCurrent()) {
+        return CollaborationCatalogRestoreResult(
+          installedSessionIds: List.unmodifiable(installed),
+          issues: List.unmodifiable(issues),
+          cancelled: true,
+        );
+      }
+      issues.add(
+        CollaborationCatalogRestoreIssue(
+          sessionId: remote.sessionId,
+          title: remote.title,
+          error: error,
+        ),
+      );
+    }
+  }
+
+  return CollaborationCatalogRestoreResult(
+    installedSessionIds: List.unmodifiable(installed),
+    issues: List.unmodifiable(issues),
+    cancelled: false,
+  );
+}

--- a/lib/widgets/font_picker_dialog.dart
+++ b/lib/widgets/font_picker_dialog.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart' show ScrollCacheExtent;
 import 'package:openlogtool/l10n/l10n.dart';
 import 'package:openlogtool/theme/app_theme.dart';
 
@@ -203,7 +204,7 @@ class _FontPickerDialogState extends State<FontPickerDialog> {
               child: ListView.builder(
                 key: const Key('font-list'),
                 itemExtent: 48,
-                cacheExtent: 144,
+                scrollCacheExtent: const ScrollCacheExtent.pixels(144),
                 itemCount: filtered.length + 1,
                 itemBuilder: (context, index) {
                   if (index == 0) {

--- a/lib/widgets/log_form.dart
+++ b/lib/widgets/log_form.dart
@@ -50,6 +50,18 @@ class LogForm extends StatefulWidget {
 
 class _LogFormState extends State<LogForm> with AutomaticKeepAliveClientMixin {
   static const _upperCaseDraftFields = {'controller', 'callsign'};
+  static const _clearableDraftFields = <String>{
+    'time',
+    'callsign',
+    'rstSent',
+    'rstRcvd',
+    'qth',
+    'device',
+    'power',
+    'antenna',
+    'height',
+    'remarks',
+  };
 
   final _formKey = GlobalKey<FormState>();
   final _controllerController = TextEditingController();
@@ -74,8 +86,10 @@ class _LogFormState extends State<LogForm> with AutomaticKeepAliveClientMixin {
   bool _applyingSharedDraft = false;
   bool _historyReuseInProgress = false;
   bool _submissionInProgress = false;
+  bool _clearInProgress = false;
   String? _lastSharedDraftSignature;
   String? _lastSharedDraftId;
+  bool _sharedDraftSyncScheduled = false;
   final Set<String> _deferredSharedDraftFields = <String>{};
   late final Map<String, int> _aiFieldRevisions;
   int _aiRecordEpoch = 0;
@@ -228,6 +242,20 @@ class _LogFormState extends State<LogForm> with AutomaticKeepAliveClientMixin {
     } finally {
       _applyingSharedDraft = false;
     }
+  }
+
+  void _scheduleSharedDraftSync() {
+    if (_sharedDraftSyncScheduled) return;
+    _sharedDraftSyncScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _sharedDraftSyncScheduled = false;
+      if (!mounted) return;
+      // A provider notification can rebuild this form while Windows is still
+      // dispatching a resize or IME callback. Updating TextEditingControllers
+      // from build re-enters the platform text-input connection at exactly
+      // that point. Apply the canonical draft only after the frame instead.
+      _syncSharedDraft(context.read<CollaborationProvider>());
+    });
   }
 
   void _onDraftFieldChanged(String field) {
@@ -596,6 +624,81 @@ class _LogFormState extends State<LogForm> with AutomaticKeepAliveClientMixin {
     }
   }
 
+  Future<void> _clearEnteredFields() async {
+    if (_clearInProgress || _historyReuseInProgress || _submissionInProgress) {
+      return;
+    }
+    final collaboration = context.read<CollaborationProvider>();
+    if (widget.readOnly ||
+        (collaboration.liveDraftSnapshot != null &&
+            !collaboration.canEditLiveDraft)) {
+      return;
+    }
+    final updates = <String, String>{
+      for (final field in _clearableDraftFields)
+        if (_draftControllers[field]!.text.isNotEmpty) field: '',
+    };
+    if (updates.isEmpty) return;
+
+    for (final field in _clearableDraftFields) {
+      _draftDebounce.remove(field)?.cancel();
+    }
+    collaboration.cancelAutomaticLiveDraftTime();
+    _unfocusDraftFields();
+    setState(() => _clearInProgress = true);
+    try {
+      if (collaboration.liveDraftSnapshot != null) {
+        // Do not make the UI look cleared until the shared draft accepts the
+        // whole operation. This also prevents one field from being left behind
+        // when a collaborator owns a lock.
+        await collaboration.updateLiveDraftFieldsAtomically(updates);
+      }
+      if (!mounted) return;
+      _applyClearedFieldsLocally();
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(context.l10n.enteredFieldsCleared),
+          duration: const Duration(seconds: 2),
+        ),
+      );
+    } catch (error) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(context.l10n.operationFailed('$error'))),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _clearInProgress = false);
+    }
+  }
+
+  void _applyClearedFieldsLocally() {
+    _aiRecordEpoch += 1;
+    for (final timer in _inlineAiDebounce.values) {
+      timer.cancel();
+    }
+    _inlineAiDebounce.clear();
+    for (final token in _inlineAiTokens.values) {
+      token.cancel();
+    }
+    _inlineAiTokens.clear();
+    _inlineAiSuggestions.clear();
+    _inlineAiPending.clear();
+    _acceptedInlineAiValues.clear();
+
+    final controllerCallsign = _controllerController.text;
+    _applyingSharedDraft = true;
+    try {
+      _formKey.currentState?.reset();
+      _controllerController.text = controllerCallsign;
+      for (final field in _clearableDraftFields) {
+        _draftControllers[field]!.clear();
+      }
+    } finally {
+      _applyingSharedDraft = false;
+    }
+  }
+
   Future<void> _submitValidatedForm(
     CollaborationProvider collaboration,
   ) async {
@@ -810,7 +913,8 @@ class _LogFormState extends State<LogForm> with AutomaticKeepAliveClientMixin {
       composingFields: composingFields,
       lockedFields: lockedFields,
       readOnly: readOnly,
-      busy: _historyReuseInProgress || _submissionInProgress,
+      busy:
+          _historyReuseInProgress || _clearInProgress || _submissionInProgress,
     );
   }
 
@@ -877,7 +981,7 @@ class _LogFormState extends State<LogForm> with AutomaticKeepAliveClientMixin {
     final settingsProvider = Provider.of<SettingsProvider>(context);
     final collaboration = Provider.of<CollaborationProvider>(context);
     final aiSettings = Provider.of<AiRecognitionSettingsProvider?>(context);
-    _syncSharedDraft(collaboration);
+    _scheduleSharedDraftSync();
     final sharedDraft = collaboration.liveDraftSnapshot != null;
     final readOnly =
         widget.readOnly || (sharedDraft && !collaboration.canEditLiveDraft);
@@ -899,9 +1003,18 @@ class _LogFormState extends State<LogForm> with AutomaticKeepAliveClientMixin {
     _scheduleLockExpiryRefresh(activeForeignLocks);
     final firstForeignLock =
         activeForeignLocks.isEmpty ? null : activeForeignLocks.first;
+    final clearableForeignLocks = activeForeignLocks
+        .where((lock) => _clearableDraftFields.contains(lock.field))
+        .toList(growable: false);
     final canSubmit = !readOnly &&
         firstForeignLock == null &&
         !_historyReuseInProgress &&
+        !_clearInProgress &&
+        !_submissionInProgress;
+    final canClear = !readOnly &&
+        clearableForeignLocks.isEmpty &&
+        !_historyReuseInProgress &&
+        !_clearInProgress &&
         !_submissionInProgress;
 
     bool fieldEnabled(String field) => !readOnly && !isActiveForeignLock(field);
@@ -930,7 +1043,7 @@ class _LogFormState extends State<LogForm> with AutomaticKeepAliveClientMixin {
 
         return AbsorbPointer(
           key: const Key('history-reuse-guard'),
-          absorbing: _historyReuseInProgress,
+          absorbing: _historyReuseInProgress || _clearInProgress,
           child: Form(
             key: _formKey,
             child: Column(
@@ -1162,7 +1275,9 @@ class _LogFormState extends State<LogForm> with AutomaticKeepAliveClientMixin {
                       collaboration,
                     ),
                     readOnly: readOnly,
-                    busy: _historyReuseInProgress || _submissionInProgress,
+                    busy: _historyReuseInProgress ||
+                        _clearInProgress ||
+                        _submissionInProgress,
                     audioRecorder: widget.aiAudioRecorder,
                     executor: widget.aiRecognitionExecutor,
                     transcriptionExecutor: widget.aiTranscriptionExecutor ??
@@ -1188,46 +1303,85 @@ class _LogFormState extends State<LogForm> with AutomaticKeepAliveClientMixin {
                     collaboration.ownedLiveDraftLocks.isNotEmpty) ...[
                   OutlinedButton.icon(
                     key: const Key('finish-draft-editing'),
-                    onPressed:
-                        _historyReuseInProgress ? null : _unfocusDraftFields,
+                    onPressed: _historyReuseInProgress || _clearInProgress
+                        ? null
+                        : _unfocusDraftFields,
                     icon: const Icon(Icons.keyboard_hide_outlined),
                     label: Text(context.l10n.finishEditing),
                   ),
                   const SizedBox(height: 8),
                 ],
 
-                // 操作按钮 - 占满宽度
-                Tooltip(
-                  message: 'Ctrl/⌘ + Enter',
-                  child: SizedBox(
-                    height: isNarrow ? 44 : 48,
-                    child: FilledButton.icon(
-                      key: const Key('save-log-record'),
-                      onPressed: canSubmit ? _submitForm : null,
-                      icon: Icon(
-                        _historyReuseInProgress
-                            ? Icons.auto_fix_high
-                            : readOnly || firstForeignLock != null
-                                ? Icons.lock_outline
-                                : Icons.add,
-                      ),
-                      label: Text(
-                        _historyReuseInProgress
-                            ? context.l10n.reuseDatabaseInformation
-                            : readOnly
-                                ? context.l10n.sharedDraftReadOnly
-                                : firstForeignLock != null
-                                    ? context.l10n.fieldLockedBy(
-                                        firstForeignLock.username,
-                                      )
-                                    : context.l10n.saveRecord,
-                      ),
-                      style: ElevatedButton.styleFrom(
-                        padding:
-                            EdgeInsets.symmetric(vertical: isNarrow ? 10 : 14),
+                // 当前草稿操作；清空保留主控呼号。
+                Row(
+                  children: [
+                    Flexible(
+                      flex: 2,
+                      child: Tooltip(
+                        message: context.l10n.clearEnteredFields,
+                        child: SizedBox(
+                          width: double.infinity,
+                          height: isNarrow ? 44 : 48,
+                          child: OutlinedButton.icon(
+                            key: const Key('clear-log-fields'),
+                            onPressed: canClear ? _clearEnteredFields : null,
+                            icon: _clearInProgress
+                                ? const SizedBox.square(
+                                    dimension: 18,
+                                    child: CircularProgressIndicator(
+                                      strokeWidth: 2,
+                                    ),
+                                  )
+                                : const Icon(Icons.backspace_outlined),
+                            label: Text(
+                              context.l10n.clearEnteredFields,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                        ),
                       ),
                     ),
-                  ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      flex: 3,
+                      child: Tooltip(
+                        message: 'Ctrl/⌘ + Enter',
+                        child: SizedBox(
+                          height: isNarrow ? 44 : 48,
+                          child: FilledButton.icon(
+                            key: const Key('save-log-record'),
+                            onPressed: canSubmit ? _submitForm : null,
+                            icon: Icon(
+                              _historyReuseInProgress
+                                  ? Icons.auto_fix_high
+                                  : readOnly || firstForeignLock != null
+                                      ? Icons.lock_outline
+                                      : Icons.add,
+                            ),
+                            label: Text(
+                              _historyReuseInProgress
+                                  ? context.l10n.reuseDatabaseInformation
+                                  : readOnly
+                                      ? context.l10n.sharedDraftReadOnly
+                                      : firstForeignLock != null
+                                          ? context.l10n.fieldLockedBy(
+                                              firstForeignLock.username,
+                                            )
+                                          : context.l10n.saveRecord,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                            style: ElevatedButton.styleFrom(
+                              padding: EdgeInsets.symmetric(
+                                vertical: isNarrow ? 10 : 14,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
                 ),
               ],
             ),

--- a/lib/widgets/session_history_dialog.dart
+++ b/lib/widgets/session_history_dialog.dart
@@ -162,13 +162,18 @@ class _SessionHistoryPanelState extends State<SessionHistoryPanel> {
   String? _busySessionId;
   int _page = 0;
   int? _databaseRevision;
+  int? _collaborationCatalogRevision;
 
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
     final sessions = context.watch<SessionProvider>();
-    if (_entries == null || _databaseRevision != sessions.databaseRevision) {
+    if (_entries == null ||
+        _databaseRevision != sessions.databaseRevision ||
+        _collaborationCatalogRevision !=
+            sessions.collaborationCatalogRevision) {
       _databaseRevision = sessions.databaseRevision;
+      _collaborationCatalogRevision = sessions.collaborationCatalogRevision;
       _entries = sessions.listAvailableSessionEntries();
       _busySessionId = null;
       _page = 0;

--- a/lib/widgets/settings_panel.dart
+++ b/lib/widgets/settings_panel.dart
@@ -174,30 +174,36 @@ class _SettingsPanelState extends State<SettingsPanel> {
           for (final category in _SettingsCategory.values)
             Padding(
               padding: const EdgeInsets.symmetric(vertical: AppSpace.xxs),
-              child: ListTile(
-                key: Key('settings-category-${category.name}'),
-                selected: selected == category,
-                selectedTileColor: colors.primaryContainer,
-                selectedColor: colors.onPrimaryContainer,
-                leading: AppIconBadge(
-                  icon: category.icon,
-                  tone:
-                      selected == category ? AppTone.primary : AppTone.neutral,
-                  size: AppIconBadgeSize.action,
+              child: Material(
+                color: Colors.transparent,
+                borderRadius: BorderRadius.circular(AppRadius.control),
+                clipBehavior: Clip.antiAlias,
+                child: ListTile(
+                  key: Key('settings-category-${category.name}'),
+                  selected: selected == category,
+                  selectedTileColor: colors.primaryContainer,
+                  selectedColor: colors.onPrimaryContainer,
+                  leading: AppIconBadge(
+                    icon: category.icon,
+                    tone: selected == category
+                        ? AppTone.primary
+                        : AppTone.neutral,
+                    size: AppIconBadgeSize.action,
+                  ),
+                  title: Text(
+                    category.label(context),
+                    style: const TextStyle(fontWeight: FontWeight.w600),
+                  ),
+                  subtitle: Text(
+                    category.description(context),
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  trailing: selected == null
+                      ? const Icon(Icons.chevron_right, size: 20)
+                      : null,
+                  onTap: () => onSelected(category),
                 ),
-                title: Text(
-                  category.label(context),
-                  style: const TextStyle(fontWeight: FontWeight.w600),
-                ),
-                subtitle: Text(
-                  category.description(context),
-                  maxLines: 2,
-                  overflow: TextOverflow.ellipsis,
-                ),
-                trailing: selected == null
-                    ? const Icon(Icons.chevron_right, size: 20)
-                    : null,
-                onTap: () => onSelected(category),
               ),
             ),
         ],

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -521,10 +521,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -1078,10 +1078,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: openlogtool
 description: OpenLogTool
 publish_to: 'none'
-version: 2.6.0-R+12
+version: 2.6.1-R+13
 license: AGPL-3.0
 homepage: https://github.com/Mazha0309/OpenLogTool
 repository: https://github.com/Mazha0309/OpenLogTool.git

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1016,7 +1016,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openlogtool_core"
-version = "2.6.0-R"
+version = "2.6.1-R"
 dependencies = [
  "anyhow",
  "chrono",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openlogtool_core"
-version = "2.6.0-R"
+version = "2.6.1-R"
 edition = "2021"
 license = "AGPL-3.0"
 

--- a/test/screens/home_screen_focus_test.dart
+++ b/test/screens/home_screen_focus_test.dart
@@ -81,6 +81,45 @@ void main() {
       ScrollViewKeyboardDismissBehavior.onDrag,
     );
   });
+
+  testWidgets(
+    'resizing across navigation breakpoints preserves the focused form',
+    (tester) async {
+      tester.view.physicalSize = const Size(680, 960);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(const _HomeScreenTestApp());
+      await tester.pumpAndSettle();
+
+      final formFinder = find.byType(LogForm);
+      final initialState = tester.state(formFinder);
+      final editableFinder = find.byType(EditableText).first;
+      final editable = tester.widget<EditableText>(editableFinder);
+      editable.focusNode.requestFocus();
+      await tester.enterText(editableFinder, 'BG5CRL');
+      expect(editable.focusNode.hasFocus, isTrue);
+
+      for (final size in const <Size>[
+        Size(900, 960),
+        Size(1280, 960),
+        Size(650, 960),
+        Size(1440, 960),
+        Size(700, 960),
+      ]) {
+        tester.view.physicalSize = size;
+        await tester.pump();
+        expect(tester.takeException(), isNull);
+        expect(tester.state(formFinder), same(initialState));
+        expect(
+          tester.widget<EditableText>(editableFinder).controller.text,
+          'BG5CRL',
+        );
+        expect(editable.focusNode.hasFocus, isTrue);
+      }
+    },
+  );
 }
 
 class _HomeScreenTestApp extends StatelessWidget {

--- a/test/services/collaboration_catalog_restore_test.dart
+++ b/test/services/collaboration_catalog_restore_test.dart
@@ -1,0 +1,119 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openlogtool/models/collaboration_dto.dart';
+import 'package:openlogtool/services/collaboration_catalog_restore.dart';
+
+void main() {
+  group('restoreMissingCollaborationSessions', () {
+    test('restores active and closed sessions while skipping ineligible ones',
+        () async {
+      final installed = <String>[];
+      final result = await restoreMissingCollaborationSessions(
+        remoteSessions: [
+          _session('existing'),
+          _session('active'),
+          _session('closed', status: 'closed'),
+          _session('initializing', status: 'initializing'),
+          _session('deleted', deleted: true),
+        ],
+        accountId: 'account-1',
+        bindingExists: (id) async => id == 'existing',
+        loadMembership: (id) async => _membership(id),
+        loadSnapshot: (id) async => _snapshot(id),
+        installSnapshot: ({required membership, required snapshot}) async {
+          expect(membership.sessionId, snapshot.session.sessionId);
+          installed.add(snapshot.session.sessionId);
+        },
+      );
+
+      expect(installed, ['active', 'closed']);
+      expect(result.installedSessionIds, ['active', 'closed']);
+      expect(result.issues, isEmpty);
+      expect(result.cancelled, isFalse);
+    });
+
+    test('isolates a malformed session and continues restoring the catalog',
+        () async {
+      final installed = <String>[];
+      final result = await restoreMissingCollaborationSessions(
+        remoteSessions: [_session('bad'), _session('good')],
+        accountId: 'account-1',
+        bindingExists: (_) async => false,
+        loadMembership: (id) async =>
+            _membership(id, userId: id == 'bad' ? 'other-account' : 'account-1'),
+        loadSnapshot: (id) async => _snapshot(id),
+        installSnapshot: ({required membership, required snapshot}) async {
+          installed.add(snapshot.session.sessionId);
+        },
+      );
+
+      expect(installed, ['good']);
+      expect(result.installedSessionIds, ['good']);
+      expect(result.issues, hasLength(1));
+      expect(result.issues.single.sessionId, 'bad');
+      expect(result.cancelled, isFalse);
+    });
+
+    test('stops without starting another install after the scope changes',
+        () async {
+      var current = true;
+      final result = await restoreMissingCollaborationSessions(
+        remoteSessions: [_session('first'), _session('second')],
+        accountId: 'account-1',
+        bindingExists: (_) async => false,
+        loadMembership: (id) async => _membership(id),
+        loadSnapshot: (id) async => _snapshot(id),
+        installSnapshot: ({required membership, required snapshot}) async {
+          current = false;
+        },
+        isCurrent: () => current,
+      );
+
+      expect(result.installedSessionIds, isEmpty);
+      expect(result.issues, isEmpty);
+      expect(result.cancelled, isTrue);
+    });
+  });
+}
+
+final _now = DateTime.utc(2026, 7, 22, 12);
+
+CollaborationSessionDto _session(
+  String id, {
+  String status = 'active',
+  bool deleted = false,
+}) =>
+    CollaborationSessionDto(
+      sessionId: id,
+      title: 'Session $id',
+      status: status,
+      version: 1,
+      role: SessionRole.editor,
+      highWatermarkSeq: 0,
+      createdAt: _now,
+      updatedAt: _now,
+      closedAt: status == 'closed' ? _now : null,
+      deletedAt: deleted ? _now : null,
+    );
+
+MembershipDto _membership(
+  String sessionId, {
+  String userId = 'account-1',
+}) =>
+    MembershipDto(
+      membershipId: 'membership-$sessionId',
+      sessionId: sessionId,
+      userId: userId,
+      role: SessionRole.editor,
+      version: 1,
+      joinedAt: _now,
+      updatedAt: _now,
+      removedAt: null,
+    );
+
+SessionSnapshotDto _snapshot(String sessionId) => SessionSnapshotDto(
+      protocolVersion: 1,
+      session: _session(sessionId),
+      highWatermarkSeq: 0,
+      includesDeletedLogs: false,
+      logs: const [],
+    );

--- a/test/widgets/log_form_collaboration_test.dart
+++ b/test/widgets/log_form_collaboration_test.dart
@@ -96,6 +96,10 @@ void main() {
         remarksDecoration.hintText,
         isEnglish ? 'Remarks (optional)' : '备注（可选）',
       );
+      expect(
+        find.text(isEnglish ? 'Clear fields' : '清空已填内容'),
+        findsOneWidget,
+      );
 
       tester
           .widget<FilledButton>(find.byKey(const Key('save-log-record')))
@@ -146,6 +150,109 @@ void main() {
       expect(collaboration.commitCalls, 1);
     });
   }
+
+  testWidgets(
+    'clear fields keeps the controller callsign and updates collaboration atomically',
+    (tester) async {
+      final collaboration = _RecordingCollaborationProvider(
+        initialTimeRevision: 1,
+        initialFields: const {
+          'time': '12:34',
+          'controller': 'BG5CRL',
+          'callsign': 'BA4AAA',
+          'rstSent': '58',
+          'rstRcvd': '47',
+          'qth': 'Shanghai',
+          'device': 'IC-7300',
+          'power': '100W',
+          'antenna': 'DP',
+          'height': '12m',
+          'remarks': 'portable',
+        },
+      );
+      addTearDown(collaboration.dispose);
+
+      await tester.pumpWidget(_LogFormTestApp(collaboration: collaboration));
+      await tester.pumpAndSettle();
+
+      TextEditingController controllerFor(String label) => tester
+          .widget<TextFormField>(
+            find.ancestor(
+              of: find.text(label),
+              matching: find.byType(TextFormField),
+            ),
+          )
+          .controller!;
+
+      await tester.tap(find.byKey(const Key('clear-log-fields')));
+      await tester.pumpAndSettle();
+
+      expect(collaboration.atomicUpdates, hasLength(1));
+      expect(collaboration.atomicUpdates.single, {
+        'time': '',
+        'callsign': '',
+        'rstSent': '',
+        'rstRcvd': '',
+        'qth': '',
+        'device': '',
+        'power': '',
+        'antenna': '',
+        'height': '',
+        'remarks': '',
+      });
+      expect(collaboration.atomicUpdates.single, isNot(contains('controller')));
+      expect(controllerFor('Controller callsign *').text, 'BG5CRL');
+      for (final label in const <String>[
+        'Callsign',
+        'Radio',
+        'Antenna',
+        'Power',
+        'QTH',
+        'Height',
+        'Time',
+        'RST sent',
+        'RST received',
+        'Remarks',
+      ]) {
+        expect(controllerFor(label).text, isEmpty, reason: label);
+      }
+      expect(
+        find.text('Fields cleared; controller callsign retained'),
+        findsOneWidget,
+      );
+    },
+  );
+
+  testWidgets('clear fields also works locally without clearing controller',
+      (tester) async {
+    final collaboration = _LocalOnlyCollaborationProvider();
+    addTearDown(collaboration.dispose);
+
+    await tester.pumpWidget(_LogFormTestApp(collaboration: collaboration));
+    await tester.pumpAndSettle();
+
+    TextEditingController controllerFor(String label) => tester
+        .widget<TextFormField>(
+          find.ancestor(
+            of: find.text(label),
+            matching: find.byType(TextFormField),
+          ),
+        )
+        .controller!;
+
+    controllerFor('Controller callsign *').text = 'BG5CRL';
+    controllerFor('Callsign').text = 'BA4AAA';
+    controllerFor('Remarks').text = 'portable';
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('clear-log-fields')));
+    await tester.pumpAndSettle();
+
+    expect(controllerFor('Controller callsign *').text, 'BG5CRL');
+    expect(controllerFor('Callsign').text, isEmpty);
+    expect(controllerFor('RST sent').text, isEmpty);
+    expect(controllerFor('RST received').text, isEmpty);
+    expect(controllerFor('Remarks').text, isEmpty);
+  });
 
   testWidgets('save shortcut keeps invalid and read-only forms blocked',
       (tester) async {
@@ -848,6 +955,7 @@ class _RecordingCollaborationProvider extends CollaborationProvider {
       'rstSent': '59',
       'rstRcvd': '59',
     },
+    int initialTimeRevision = 0,
     this.nextDraftTime = '',
     this.nextDraftTimeRevision = 0,
   }) : _snapshot = LiveDraftSnapshotDto(
@@ -857,7 +965,8 @@ class _RecordingCollaborationProvider extends CollaborationProvider {
             version: 1,
             fields: LiveDraftFieldsDto(initialFields),
             fieldRevisions: {
-              for (final field in liveDraftFieldNames) field: 0,
+              for (final field in liveDraftFieldNames)
+                field: field == 'time' ? initialTimeRevision : 0,
             },
             lastUpdatedBy: null,
             createdAt: DateTime.utc(2026, 7, 13),
@@ -1010,6 +1119,31 @@ class _RecordingCollaborationProvider extends CollaborationProvider {
   ) async {
     atomicUpdates.add(Map<String, String>.from(updates));
     await atomicGate?.future;
+    final previous = _snapshot.draft;
+    _snapshot = LiveDraftSnapshotDto(
+      draft: LiveDraftDto(
+        draftId: previous.draftId,
+        sessionId: previous.sessionId,
+        version: previous.version + 1,
+        fields: LiveDraftFieldsDto({
+          ...previous.fields.values,
+          ...updates,
+        }),
+        fieldRevisions: {
+          for (final field in liveDraftFieldNames)
+            field: (previous.fieldRevisions[field] ?? 0) +
+                (updates.containsKey(field) ? 1 : 0),
+        },
+        lastUpdatedBy: previous.lastUpdatedBy,
+        createdAt: previous.createdAt,
+        lastUpdatedAt: DateTime.now().toUtc(),
+      ),
+      locks: _snapshot.locks,
+      currentOrdinal: _snapshot.currentOrdinal,
+      totalRecords: _snapshot.totalRecords,
+      previousRecord: _snapshot.previousRecord,
+    );
+    notifyListeners();
   }
 
   @override
@@ -1050,6 +1184,14 @@ class _RecordingCollaborationProvider extends CollaborationProvider {
     notifyListeners();
     return disposition;
   }
+}
+
+class _LocalOnlyCollaborationProvider extends CollaborationProvider {
+  @override
+  LocalCollaborationBinding? get binding => null;
+
+  @override
+  LiveDraftSnapshotDto? get liveDraftSnapshot => null;
 }
 
 class _NoopDictionaryProvider extends DictionaryProvider {


### PR DESCRIPTION
## 主要更新

- 新增账户下协作会话自动恢复，换设备或重启后无需逐个手动加入。
- 新增当前表单一键清空，保留主控呼号；协作模式采用原子同步。
- 修复协作保存后表单刷新滞后、草稿同步不稳定及 Windows 调整窗口大小时可能崩溃的问题。
- Flutter Windows 引擎升级至 3.44.7。

## 服务端配套

- 会话页面统一展示协作会话和个人云会话。
- 管理端按账户查看全部会话，并支持个人会话详情及日志分页。
- 协作会话所有者可从 WebUI 关闭自己的会话。

## 验证

- Flutter analyze
- Flutter tests: 534/534
- Cargo check --locked
