### PR TITLE
OpenLogTool 2.6.4-R: refine clear-record behavior

### DIFF
--- a/lib/config/version.dart
+++ b/lib/config/version.dart
@@ -1,1 +1,1 @@
-const String appVersion = '2.6.3-R+15';
+const String appVersion = '2.6.4-R+16';

--- a/lib/widgets/log_form.dart
+++ b/lib/widgets/log_form.dart
@@ -62,6 +62,10 @@ class _LogFormState extends State<LogForm> with AutomaticKeepAliveClientMixin {
     'height',
     'remarks',
   };
+  static const _clearedDraftDefaults = <String, String>{
+    'rstSent': '59',
+    'rstRcvd': '59',
+  };
 
   final _formKey = GlobalKey<FormState>();
   final _controllerController = TextEditingController();
@@ -634,10 +638,13 @@ class _LogFormState extends State<LogForm> with AutomaticKeepAliveClientMixin {
             !collaboration.canEditLiveDraft)) {
       return;
     }
-    final updates = <String, String>{
-      for (final field in _clearableDraftFields)
-        if (_draftControllers[field]!.text.isNotEmpty) field: '',
-    };
+    final updates = <String, String>{};
+    for (final field in _clearableDraftFields) {
+      final clearedValue = _clearedDraftDefaults[field] ?? '';
+      if (_draftControllers[field]!.text != clearedValue) {
+        updates[field] = clearedValue;
+      }
+    }
     if (updates.isEmpty) return;
 
     for (final field in _clearableDraftFields) {
@@ -692,7 +699,7 @@ class _LogFormState extends State<LogForm> with AutomaticKeepAliveClientMixin {
       _formKey.currentState?.reset();
       _controllerController.text = controllerCallsign;
       for (final field in _clearableDraftFields) {
-        _draftControllers[field]!.clear();
+        _draftControllers[field]!.text = _clearedDraftDefaults[field] ?? '';
       }
     } finally {
       _applyingSharedDraft = false;
@@ -1314,13 +1321,13 @@ class _LogFormState extends State<LogForm> with AutomaticKeepAliveClientMixin {
 
                 // 当前草稿操作；清空保留主控呼号。
                 Row(
+                  key: const Key('log-form-actions'),
                   children: [
-                    Flexible(
-                      flex: 2,
+                    SizedBox(
+                      width: isNarrow ? 160 : 180,
                       child: Tooltip(
                         message: context.l10n.clearEnteredFields,
                         child: SizedBox(
-                          width: double.infinity,
                           height: isNarrow ? 44 : 48,
                           child: OutlinedButton.icon(
                             key: const Key('clear-log-fields'),
@@ -1344,7 +1351,6 @@ class _LogFormState extends State<LogForm> with AutomaticKeepAliveClientMixin {
                     ),
                     const SizedBox(width: 8),
                     Expanded(
-                      flex: 3,
                       child: Tooltip(
                         message: 'Ctrl/⌘ + Enter',
                         child: SizedBox(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: openlogtool
 description: OpenLogTool
 publish_to: 'none'
-version: 2.6.3-R+15
+version: 2.6.4-R+16
 license: AGPL-3.0
 homepage: https://github.com/Mazha0309/OpenLogTool
 repository: https://github.com/Mazha0309/OpenLogTool.git

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1016,7 +1016,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openlogtool_core"
-version = "2.6.3-R"
+version = "2.6.4-R"
 dependencies = [
  "anyhow",
  "chrono",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openlogtool_core"
-version = "2.6.3-R"
+version = "2.6.4-R"
 edition = "2021"
 license = "AGPL-3.0"
 

--- a/test/widgets/log_form_collaboration_test.dart
+++ b/test/widgets/log_form_collaboration_test.dart
@@ -100,6 +100,17 @@ void main() {
         find.text(isEnglish ? 'Clear fields' : '清空已填内容'),
         findsOneWidget,
       );
+      expect(
+        tester.getSize(find.byKey(const Key('clear-log-fields'))).width,
+        lessThanOrEqualTo(180),
+      );
+      final actionsWidth =
+          tester.getSize(find.byKey(const Key('log-form-actions'))).width;
+      final clearWidth =
+          tester.getSize(find.byKey(const Key('clear-log-fields'))).width;
+      final saveWidth =
+          tester.getSize(find.byKey(const Key('save-log-record'))).width;
+      expect(clearWidth + 8 + saveWidth, closeTo(actionsWidth, 0.1));
 
       tester
           .widget<FilledButton>(find.byKey(const Key('save-log-record')))
@@ -191,8 +202,8 @@ void main() {
       expect(collaboration.atomicUpdates.single, {
         'time': '',
         'callsign': '',
-        'rstSent': '',
-        'rstRcvd': '',
+        'rstSent': '59',
+        'rstRcvd': '59',
         'qth': '',
         'device': '',
         'power': '',
@@ -210,12 +221,12 @@ void main() {
         'QTH',
         'Height',
         'Time',
-        'RST sent',
-        'RST received',
         'Remarks',
       ]) {
         expect(controllerFor(label).text, isEmpty, reason: label);
       }
+      expect(controllerFor('RST sent').text, '59');
+      expect(controllerFor('RST received').text, '59');
       expect(
         find.text('Fields cleared; controller callsign retained'),
         findsOneWidget,
@@ -249,8 +260,8 @@ void main() {
 
     expect(controllerFor('Controller callsign *').text, 'BG5CRL');
     expect(controllerFor('Callsign').text, isEmpty);
-    expect(controllerFor('RST sent').text, isEmpty);
-    expect(controllerFor('RST received').text, isEmpty);
+    expect(controllerFor('RST sent').text, '59');
+    expect(controllerFor('RST received').text, '59');
     expect(controllerFor('Remarks').text, isEmpty);
   });
 


### PR DESCRIPTION
## 概要

- 将清空按钮限制为紧凑宽度，并让保存记录按钮占满剩余空间
- 清空已填内容时保留主控呼号，并将 RST 发/收恢复为默认值 59
- 本地会话与协作草稿采用一致的清空结果
- 将客户端及 Rust 核心版本更新至 2.6.4-R

## 验证

- 表单协作测试 19 项通过
- Flutter Analyze 通过
- Linux Release 本地构建通过
- Cargo 锁文件校验通过